### PR TITLE
serde-1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,9 @@ version = "0.3.19"
 
 [dependencies.serde]
 optional = true
-version = ">= 0.7.0, < 0.9.0"
+version = "1.0"
+features = ["derive"]
 
 [features]
-default = ["rustc-serialize"]
+default = ["serde"]
 unstable = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,15 +19,10 @@ version = "0.2.1"
 default-features = false
 features = ["std"]
 
-[dependencies.rustc-serialize]
-optional = true
-version = "0.3.19"
-
 [dependencies.serde]
 optional = true
 version = "1.0"
-features = ["derive"]
 
 [features]
-default = ["serde"]
+default = []
 unstable = []

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -12,12 +12,6 @@ cargo test --verbose
 cargo build --no-default-features
 cargo test --no-default-features
 
-# Each isolated feature should also work everywhere.
-for feature in rustc-serialize serde; do
-  cargo build --verbose --no-default-features --features="$feature"
-  cargo test --verbose --no-default-features --features="$feature"
-done
-
-# Downgrade serde and build test the 0.7.0 channel as well
-cargo update -p serde --precise 0.7.0
-cargo build --verbose --no-default-features --features "serde"
+# It also should build with serde features
+cargo build --verbose --no-default-features --features=serde
+cargo test --verbose --no-default-features --features=serde

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -12,6 +12,8 @@ cargo test --verbose
 cargo build --no-default-features
 cargo test --no-default-features
 
-# It also should build with serde features
-cargo build --verbose --no-default-features --features=serde
-cargo test --verbose --no-default-features --features=serde
+# Each isolated feature should also work everywhere.
+for feature in serde; do
+  cargo build --verbose --no-default-features --features="$feature"
+  cargo test --verbose --no-default-features --features="$feature"
+done

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ extern crate num_traits as traits;
 extern crate rustc_serialize;
 
 #[cfg(feature = "serde")]
+#[macro_use]
 extern crate serde;
 
 use std::error::Error;
@@ -63,6 +64,7 @@ use traits::{Zero, One, Num, Inv, Float};
 /// ```
 #[derive(PartialEq, Eq, Copy, Clone, Hash, Debug, Default)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[repr(C)]
 pub struct Complex<T> {
     /// Real portion of the complex number
@@ -1070,29 +1072,6 @@ impl<T: Num + Clone> Num for Complex<T> {
     {
         from_str_generic(s, |x| -> Result<T, T::FromStrRadixErr> {
                                 T::from_str_radix(x, radix) })
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<T> serde::Serialize for Complex<T>
-    where T: serde::Serialize
-{
-    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error> where
-        S: serde::Serializer
-    {
-        (&self.re, &self.im).serialize(serializer)
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<T> serde::Deserialize for Complex<T> where
-    T: serde::Deserialize + Num + Clone
-{
-    fn deserialize<D>(deserializer: &mut D) -> Result<Self, D::Error> where
-        D: serde::Deserializer,
-    {
-        let (re, im) = try!(serde::Deserialize::deserialize(deserializer));
-        Ok(Complex::new(re, im))
     }
 }
 


### PR DESCRIPTION
serde-1.0 should be the default serialization option since rustc-serialize is already obsolete.

Note: This is a breaking change. We need to bump up the version to 0.2.