### PR TITLE
Implement std::iter::{Sum, Product}

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,9 +26,10 @@ use std::fmt;
 #[cfg(test)]
 use std::hash;
 use std::ops::{Add, Div, Mul, Neg, Sub, Rem};
+use std::iter::{Sum, Product};
 use std::str::FromStr;
 
-use traits::{Zero, One, Num, Inv, Float};
+use traits::{Zero, One, Num, NumAssign, Inv, Float};
 
 // FIXME #1284: handle complex NaN & infinity etc. This
 // probably doesn't map to C's _Complex correctly.
@@ -1066,6 +1067,46 @@ impl<T: Num + Clone> Num for Complex<T> {
     {
         from_str_generic(s, |x| -> Result<T, T::FromStrRadixErr> {
                                 T::from_str_radix(x, radix) })
+    }
+}
+
+impl<T: Clone + NumAssign> Sum for Complex<T> {
+    fn sum<I>(iter: I) -> Self where I: Iterator<Item = Self> {
+        let mut s = Self::zero();
+        for c in iter {
+            s += c;
+        }
+        s
+    }
+}
+
+impl<'a, T: 'a + Clone + NumAssign> Sum<&'a Complex<T>> for Complex<T> {
+    fn sum<I>(iter: I) -> Self where I: Iterator<Item = &'a Complex<T>> {
+        let mut s = Self::zero();
+        for c in iter {
+            s += c;
+        }
+        s
+    }
+}
+
+impl<T: Clone + NumAssign> Product for Complex<T> {
+    fn product<I>(iter: I) -> Self where I: Iterator<Item = Self> {
+        let mut s = Self::one();
+        for c in iter {
+            s *= c;
+        }
+        s
+    }
+}
+
+impl<'a, T: 'a + Clone + NumAssign> Product<&'a Complex<T>> for Complex<T> {
+    fn product<I>(iter: I) -> Self where I: Iterator<Item = &'a Complex<T>> {
+        let mut s = Self::one();
+        for c in iter {
+            s *= c;
+        }
+        s
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1958,4 +1958,18 @@ mod test {
         test("1i - 2i");
         test("+ 1 - 3.0i");
     }
+
+    #[test]
+    fn test_sum() {
+        let v = vec![_0_1i, _4_2i, _1_0i, _1_1i];
+        let _: Complex64 = v.iter().sum();
+        let _: Complex64 = v.into_iter().sum();
+    }
+
+    #[test]
+    fn test_prod() {
+        let v = vec![_0_1i, _4_2i, _1_0i, _1_1i];
+        let _: Complex64 = v.iter().product();
+        let _: Complex64 = v.into_iter().product();
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1961,15 +1961,15 @@ mod test {
 
     #[test]
     fn test_sum() {
-        let v = vec![_0_1i, _4_2i, _1_0i, _1_1i];
-        let _: Complex64 = v.iter().sum();
-        let _: Complex64 = v.into_iter().sum();
+        let v = vec![_0_1i, _1_0i];
+        assert_eq!(v.iter().sum::<Complex64>(), _1_1i);
+        assert_eq!(v.into_iter().sum::<Complex64>(), _1_1i);
     }
 
     #[test]
     fn test_prod() {
-        let v = vec![_0_1i, _4_2i, _1_0i, _1_1i];
-        let _: Complex64 = v.iter().product();
-        let _: Complex64 = v.into_iter().product();
+        let v = vec![_0_1i, _1_0i];
+        assert_eq!(v.iter().product::<Complex64>(), _0_1i);
+        assert_eq!(v.into_iter().product::<Complex64>(), _0_1i);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ use std::ops::{Add, Div, Mul, Neg, Sub, Rem};
 use std::iter::{Sum, Product};
 use std::str::FromStr;
 
-use traits::{Zero, One, Num, NumAssign, Inv, Float};
+use traits::{Zero, One, Num, Inv, Float};
 
 // FIXME #1284: handle complex NaN & infinity etc. This
 // probably doesn't map to C's _Complex correctly.
@@ -1070,43 +1070,27 @@ impl<T: Num + Clone> Num for Complex<T> {
     }
 }
 
-impl<T: Clone + NumAssign> Sum for Complex<T> {
+impl<T: Num + Clone> Sum for Complex<T> {
     fn sum<I>(iter: I) -> Self where I: Iterator<Item = Self> {
-        let mut s = Self::zero();
-        for c in iter {
-            s += c;
-        }
-        s
+        iter.fold(Self::zero(), |acc, c| acc + c)
     }
 }
 
-impl<'a, T: 'a + Clone + NumAssign> Sum<&'a Complex<T>> for Complex<T> {
+impl<'a, T: 'a + Num + Clone> Sum<&'a Complex<T>> for Complex<T> {
     fn sum<I>(iter: I) -> Self where I: Iterator<Item = &'a Complex<T>> {
-        let mut s = Self::zero();
-        for c in iter {
-            s += c;
-        }
-        s
+        iter.fold(Self::zero(), |acc, c| acc + c)
     }
 }
 
-impl<T: Clone + NumAssign> Product for Complex<T> {
+impl<T: Num + Clone> Product for Complex<T> {
     fn product<I>(iter: I) -> Self where I: Iterator<Item = Self> {
-        let mut s = Self::one();
-        for c in iter {
-            s *= c;
-        }
-        s
+        iter.fold(Self::one(), |acc, c| acc * c)
     }
 }
 
-impl<'a, T: 'a + Clone + NumAssign> Product<&'a Complex<T>> for Complex<T> {
+impl<'a, T: 'a + Num + Clone> Product<&'a Complex<T>> for Complex<T> {
     fn product<I>(iter: I) -> Self where I: Iterator<Item = &'a Complex<T>> {
-        let mut s = Self::one();
-        for c in iter {
-            s *= c;
-        }
-        s
+        iter.fold(Self::one(), |acc, c| acc * c)
     }
 }
 


### PR DESCRIPTION
Resolve #3 

- Implement `Sum<Complex<T>>` and `Sum<&Complex<T>>` using `Zero` + `AddAssign`
- Implement `Product<Complex<T>>` and `Product<&Complex<T>>` using `One` + `MulAssign`

`Num` and `NumAssign` are used for type constraint.