### PR TITLE
Implementing rand::Rand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,10 @@ features = ["std"]
 optional = true
 version = "1.0"
 
+[dependencies.rand]
+optional = true
+version = "= 0.3.14"
+
 [features]
 default = []
 unstable = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ version = "1.0"
 
 [dependencies.rand]
 optional = true
-version = "= 0.3.14"
+version = "0.4"
 
 [features]
 default = []

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -13,7 +13,10 @@ cargo build --no-default-features
 cargo test --no-default-features
 
 # Each isolated feature should also work everywhere.
-for feature in serde; do
+for feature in rand serde; do
   cargo build --verbose --no-default-features --features="$feature"
   cargo test --verbose --no-default-features --features="$feature"
 done
+
+cargo build --all-features
+cargo test --all-features

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,9 @@ extern crate num_traits as traits;
 #[cfg(feature = "serde")]
 extern crate serde;
 
+#[cfg(feature = "rand")]
+extern crate rand;
+
 use std::error::Error;
 use std::fmt;
 #[cfg(test)]
@@ -1114,6 +1117,15 @@ impl<'de, T> serde::Deserialize<'de> for Complex<T> where
     {
         let (re, im) = try!(serde::Deserialize::deserialize(deserializer));
         Ok(Complex::new(re, im))
+    }
+}
+
+#[cfg(feature = "rand")]
+impl<T> rand::Rand for Complex<T> where
+    T: rand::Rand + Num + Clone
+{
+    fn rand<R:rand::Rng>(rng: &mut R) -> Self {
+        Self::new(rng.gen::<T>(), rng.gen::<T>())
     }
 }
 


### PR DESCRIPTION
Implements #12 .

Right now it is implemented with calling `rng.gen::<T>()` for both the real and imaginary parts. I'm not 100% sure on the mathematical randomness of the distribution if the complex number is used as a vector and the angle is wanted.

As well as that, for the dependency on `rand`, I just pulled the newest version on crates.io, but it may be better to use another version. I don't have many projects that use this so I'm not sure how big of an issue this will be.

Changes:

- Optional `rand` feature and dependency on `rand`
- `impl<T> rand::Rand for Complex<T>`