### PR TITLE
Fix typo on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ num-complex = "0.1"
 and this to your crate root:
 
 ```rust
-extern crate num_compex;
+extern crate num_complex;
 ```
 
 ## Releases


### PR DESCRIPTION
`num-compex` => `num-complex`.

May be good to publish a new version to crates.io so that the README is fixed there