### PR TITLE
Add no_std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "Complex numbers implementation for Rust"
 documentation = "https://docs.rs/num-complex"
 homepage = "https://github.com/rust-num/num-complex"
 keywords = ["mathematics", "numerics"]
-categories = [ "algorithms", "data-structures", "science" ]
+categories = ["algorithms", "data-structures", "science", "no-std"]
 license = "MIT/Apache-2.0"
 name = "num-complex"
 repository = "https://github.com/rust-num/num-complex"
@@ -12,21 +12,25 @@ version = "0.2.0-git"
 publish = false
 readme = "README.md"
 
+[package.metadata.docs.rs]
+all-features = true
+
 [dependencies]
 
 [dependencies.num-traits]
 version = "0.2.1"
 default-features = false
-features = ["std"]
 
 [dependencies.serde]
 optional = true
 version = "1.0"
+default-features = false
 
 [dependencies.rand]
 optional = true
 version = "0.4"
+default-features = false
 
 [features]
-default = []
-unstable = []
+default = ["std"]
+std = ["num-traits/std"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![crate](https://img.shields.io/crates/v/num-complex.svg)](https://crates.io/crates/num-complex)
 [![documentation](https://docs.rs/num-complex/badge.svg)](https://docs.rs/num-complex)
-![minimum rustc 1.8](https://img.shields.io/badge/rustc-1.8+-red.svg)
+![minimum rustc 1.8](https://img.shields.io/badge/rustc-1.15+-red.svg)
 [![Travis status](https://travis-ci.org/rust-num/num-complex.svg?branch=master)](https://travis-ci.org/rust-num/num-complex)
 
 `Complex` numbers for Rust.
@@ -13,7 +13,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-num-complex = "0.1"
+num-complex = "0.2"
 ```
 
 and this to your crate root:
@@ -22,10 +22,25 @@ and this to your crate root:
 extern crate num_complex;
 ```
 
+## Features
+
+This crate can be used without the standard library (`#![no_std]`) by disabling
+the default `std` feature. Use this in `Cargo.toml`:
+
+```toml
+[dependencies.num-complex]
+version = "0.2"
+default-features = false
+```
+
+Features based on `Float` types are only available when `std` is enabled. Where
+possible, `FloatCore` is used instead.  Formatting complex numbers only supports
+format width when `std` is enabled.
+
 ## Releases
 
 Release notes are available in [RELEASES.md](RELEASES.md).
 
 ## Compatibility
 
-The `num-complex` crate is tested for rustc 1.8 and greater.
+The `num-complex` crate is tested for rustc 1.15 and greater.


### PR DESCRIPTION
Based on @termoshtt's #15, without the intrusive file splitting.  I also
addressed the other review comments I had left there.  The limitations
of `no_std` are the missing implementations of `Error` and methods based
on `Float`, although `FloatCore` is now used for a few things.  Format
widths are also not supported, as I couldn't find a way to do this
without using a temporary `String`.

Fixes #6.
Closes #15.