### PR TITLE
Implement 128-bit Gaussian integers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: rust
 rust:
   - 1.15.0
+  - 1.20.0
+  - 1.25.0
   - stable
   - beta
   - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,15 @@ repository = "https://github.com/rust-num/num-complex"
 version = "0.2.0-git"
 publish = false
 readme = "README.md"
+build = "build.rs"
 
 [package.metadata.docs.rs]
-all-features = true
+features = ["std"]
 
 [dependencies]
 
 [dependencies.num-traits]
-version = "0.2.1"
+version = "0.2.4"
 default-features = false
 
 [dependencies.serde]
@@ -33,4 +34,5 @@ default-features = false
 
 [features]
 default = ["std"]
+i128 = ["num-traits/i128"]
 std = ["num-traits/std"]

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ Features based on `Float` types are only available when `std` is enabled. Where
 possible, `FloatCore` is used instead.  Formatting complex numbers only supports
 format width when `std` is enabled.
 
+Implementations for `i128` and `u128` are only available with Rust 1.26 and
+later.  The build script automatically detects this, but you can make it
+mandatory by enabling the `i128` crate feature.
+
 ## Releases
 
 Release notes are available in [RELEASES.md](RELEASES.md).

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,35 @@
+use std::env;
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn main() {
+    if probe("fn main() { 0i128; }") {
+        println!("cargo:rustc-cfg=has_i128");
+    } else if env::var_os("CARGO_FEATURE_I128").is_some() {
+        panic!("i128 support was not detected!");
+    }
+}
+
+/// Test if a code snippet can be compiled
+fn probe(code: &str) -> bool {
+    let rustc = env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
+    let out_dir = env::var_os("OUT_DIR").expect("environment variable OUT_DIR");
+
+    let mut child = Command::new(rustc)
+        .arg("--out-dir")
+        .arg(out_dir)
+        .arg("--emit=obj")
+        .arg("-")
+        .stdin(Stdio::piped())
+        .spawn()
+        .expect("rustc probe");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("rustc stdin")
+        .write_all(code.as_bytes())
+        .expect("write rustc stdin");
+
+    child.wait().expect("rustc probe").success()
+}

--- a/ci/rustup.sh
+++ b/ci/rustup.sh
@@ -5,7 +5,7 @@
 set -ex
 
 export TRAVIS_RUST_VERSION
-for TRAVIS_RUST_VERSION in 1.15.0 stable beta nightly; do
+for TRAVIS_RUST_VERSION in 1.15.0 1.20.0 1.25.0 stable beta nightly; do
     run="rustup run $TRAVIS_RUST_VERSION"
     $run cargo build --verbose
     $run $PWD/ci/test_full.sh

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -4,6 +4,11 @@ set -ex
 
 echo Testing num-complex on rustc ${TRAVIS_RUST_VERSION}
 
+FEATURES="std rand serde"
+if [[ "$TRAVIS_RUST_VERSION" =~ ^(nightly|beta|stable)$ ]]; then
+  FEATURES="$FEATURES i128"
+fi
+
 # num-complex should build and test everywhere.
 cargo build --verbose
 cargo test --verbose
@@ -13,10 +18,11 @@ cargo build --no-default-features
 cargo test --no-default-features
 
 # Each isolated feature should also work everywhere.
-for feature in rand serde; do
+for feature in $FEATURES; do
   cargo build --verbose --no-default-features --features="$feature"
   cargo test --verbose --no-default-features --features="$feature"
 done
 
-cargo build --all-features
-cargo test --all-features
+# test all supported features together
+cargo build --features="$FEATURES"
+cargo test --features="$FEATURES"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -853,7 +853,10 @@ impl<T: Clone + Num> Rem<T> for Complex<T> {
     }
 }
 
+#[cfg(not(has_i128))]
 real_arithmetic!(usize, u8, u16, u32, u64, isize, i8, i16, i32, i64, f32, f64);
+#[cfg(has_i128)]
+real_arithmetic!(usize, u8, u16, u32, u64, u128, isize, i8, i16, i32, i64, i128, f32, f64);
 
 /* constants */
 impl<T: Clone + Num> Zero for Complex<T> {


### PR DESCRIPTION
The build script detects support for `u128` and `i128` (Rust 1.26+) and
enables their `Complex` implementations.  We only have to directly
implement the operators with scalar LHS, and the rest comes from
enabling num-traits' 128-bit `Num`.