### PR TITLE
From/To/AsPrimitive and NumCast for Complex<T>

### DIFF
--- a/src/cast.rs
+++ b/src/cast.rs
@@ -79,3 +79,41 @@ where
         self.re.as_()
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_to_primitive() {
+        let a: Complex<u32> = Complex { re: 3, im: 0 };
+        assert_eq!(a.to_i32(), Some(3_i32));
+        let b: Complex<u32> = Complex { re: 3, im: 1 };
+        assert_eq!(b.to_i32(), None);
+        let x: Complex<f32> = Complex { re: 1.0, im: 0.1 };
+        assert_eq!(x.to_f32(), None);
+        let y: Complex<f32> = Complex { re: 1.0, im: 0.0 };
+        assert_eq!(y.to_f32(), Some(1.0));
+        let z: Complex<f32> = Complex { re: 1.0, im: 0.0 };
+        assert_eq!(z.to_i32(), Some(1));
+    }
+
+    #[test]
+    fn test_from_primitive() {
+        let a: Complex<f32> = FromPrimitive::from_i32(2).unwrap();
+        assert_eq!(a, Complex { re: 2.0, im: 0.0 });
+    }
+
+    #[test]
+    fn test_num_cast() {
+        let a: Complex<f32> = NumCast::from(2_i32).unwrap();
+        assert_eq!(a, Complex { re: 2.0, im: 0.0 });
+    }
+
+    #[test]
+    fn test_as_primitive() {
+        let a: Complex<f32> = Complex { re: 2.0, im: 0.2 };
+        let a_: i32 = a.as_();
+        assert_eq!(a_, 2_i32);
+    }
+}

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -1,5 +1,5 @@
 use super::Complex;
-use traits::{FromPrimitive, Num, ToPrimitive, Zero};
+use traits::{FromPrimitive, Num, NumCast, ToPrimitive, Zero};
 
 macro_rules! impl_to_primitive {
     ($ty:ty, $to:ident) => {
@@ -59,4 +59,13 @@ impl<T: FromPrimitive + Zero> FromPrimitive for Complex<T> {
     impl_from_primitive!(i128, from_i128);
     impl_from_primitive!(f32, from_f32);
     impl_from_primitive!(f64, from_f64);
+}
+
+impl<T: NumCast + Num> NumCast for Complex<T> {
+    fn from<U: ToPrimitive>(n: U) -> Option<Self> {
+        Some(Self {
+            re: T::from(n)?,
+            im: T::zero(),
+        })
+    }
 }

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -1,5 +1,5 @@
 use super::Complex;
-use traits::{Num, ToPrimitive};
+use traits::{FromPrimitive, Num, ToPrimitive, Zero};
 
 macro_rules! impl_to_primitive { ($ty:ty, $to:ident) => {
 #[inline]
@@ -26,4 +26,35 @@ impl<T: ToPrimitive + Num> ToPrimitive for Complex<T> {
     impl_to_primitive!(i128, to_i128);
     impl_to_primitive!(f32, to_f32);
     impl_to_primitive!(f64, to_f64);
+}
+
+macro_rules! impl_from_primitive {
+    ($ty:ty, $from_xx:ident) => {
+        #[inline]
+        fn $from_xx(n: $ty) -> Option<Self> {
+            Some(Self {
+                re: T::$from_xx(n)?,
+                im: T::zero(),
+            })
+        }
+    };
+} // impl_from_primitive
+
+impl<T: FromPrimitive + Zero> FromPrimitive for Complex<T> {
+    impl_from_primitive!(usize, from_usize);
+    impl_from_primitive!(isize, from_isize);
+    impl_from_primitive!(u8, from_u8);
+    impl_from_primitive!(u16, from_u16);
+    impl_from_primitive!(u32, from_u32);
+    impl_from_primitive!(u64, from_u64);
+    impl_from_primitive!(i8, from_i8);
+    impl_from_primitive!(i16, from_i16);
+    impl_from_primitive!(i32, from_i32);
+    impl_from_primitive!(i64, from_i64);
+    #[cfg(has_i128)]
+    impl_from_primitive!(u128, from_u128);
+    #[cfg(has_i128)]
+    impl_from_primitive!(i128, from_i128);
+    impl_from_primitive!(f32, from_f32);
+    impl_from_primitive!(f64, from_f64);
 }

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -5,7 +5,7 @@ macro_rules! impl_to_primitive {
     ($ty:ty, $to:ident) => {
         #[inline]
         fn $to(&self) -> Option<$ty> {
-            if self.im == T::zero() { self.re.$to() } else { None }
+            if self.im.is_zero() { self.re.$to() } else { None }
         }
     }
 } // impl_to_primitive

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -1,5 +1,5 @@
 use super::Complex;
-use traits::{FromPrimitive, Num, NumCast, ToPrimitive, Zero};
+use traits::{AsPrimitive, FromPrimitive, Num, NumCast, ToPrimitive, Zero};
 
 macro_rules! impl_to_primitive {
     ($ty:ty, $to:ident) => {
@@ -67,5 +67,15 @@ impl<T: NumCast + Num> NumCast for Complex<T> {
             re: T::from(n)?,
             im: T::zero(),
         })
+    }
+}
+
+impl<T, U> AsPrimitive<U> for Complex<T>
+where
+    T: AsPrimitive<U>,
+    U: 'static + Copy,
+{
+    fn as_(self) -> U {
+        self.re.as_()
     }
 }

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -1,0 +1,29 @@
+use super::Complex;
+use traits::{Num, ToPrimitive};
+
+macro_rules! impl_to_primitive { ($ty:ty, $to:ident) => {
+#[inline]
+fn $to(&self) -> Option<$ty> {
+    if self.im == T::zero() { self.re.$to() } else { None }
+}
+}} // impl_to_primitive
+
+// Returns None if Complex part is non-zero
+impl<T: ToPrimitive + Num> ToPrimitive for Complex<T> {
+    impl_to_primitive!(usize, to_usize);
+    impl_to_primitive!(isize, to_isize);
+    impl_to_primitive!(u8, to_u8);
+    impl_to_primitive!(u16, to_u16);
+    impl_to_primitive!(u32, to_u32);
+    impl_to_primitive!(u64, to_u64);
+    impl_to_primitive!(i8, to_i8);
+    impl_to_primitive!(i16, to_i16);
+    impl_to_primitive!(i32, to_i32);
+    impl_to_primitive!(i64, to_i64);
+    #[cfg(has_i128)]
+    impl_to_primitive!(u128, to_u128);
+    #[cfg(has_i128)]
+    impl_to_primitive!(i128, to_i128);
+    impl_to_primitive!(f32, to_f32);
+    impl_to_primitive!(f64, to_f64);
+}

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -1,12 +1,14 @@
 use super::Complex;
 use traits::{FromPrimitive, Num, ToPrimitive, Zero};
 
-macro_rules! impl_to_primitive { ($ty:ty, $to:ident) => {
-#[inline]
-fn $to(&self) -> Option<$ty> {
-    if self.im == T::zero() { self.re.$to() } else { None }
-}
-}} // impl_to_primitive
+macro_rules! impl_to_primitive {
+    ($ty:ty, $to:ident) => {
+        #[inline]
+        fn $to(&self) -> Option<$ty> {
+            if self.im == T::zero() { self.re.$to() } else { None }
+        }
+    }
+} // impl_to_primitive
 
 // Returns None if Complex part is non-zero
 impl<T: ToPrimitive + Num> ToPrimitive for Complex<T> {

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -1,5 +1,5 @@
 use super::Complex;
-use traits::{AsPrimitive, FromPrimitive, Num, NumCast, ToPrimitive, Zero};
+use traits::{AsPrimitive, FromPrimitive, Num, NumCast, ToPrimitive};
 
 macro_rules! impl_to_primitive {
     ($ty:ty, $to:ident) => {
@@ -42,7 +42,7 @@ macro_rules! impl_from_primitive {
     };
 } // impl_from_primitive
 
-impl<T: FromPrimitive + Zero> FromPrimitive for Complex<T> {
+impl<T: FromPrimitive + Num> FromPrimitive for Complex<T> {
     impl_from_primitive!(usize, from_usize);
     impl_from_primitive!(isize, from_isize);
     impl_from_primitive!(u8, from_u8);

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -34,10 +34,7 @@ macro_rules! impl_from_primitive {
     ($ty:ty, $from_xx:ident) => {
         #[inline]
         fn $from_xx(n: $ty) -> Option<Self> {
-            Some(Self {
-                re: T::$from_xx(n)?,
-                im: T::zero(),
-            })
+            T::$from_xx(n).map(|re| Complex { re, im: T::zero() })
         }
     };
 } // impl_from_primitive
@@ -63,10 +60,7 @@ impl<T: FromPrimitive + Zero> FromPrimitive for Complex<T> {
 
 impl<T: NumCast + Num> NumCast for Complex<T> {
     fn from<U: ToPrimitive>(n: U) -> Option<Self> {
-        Some(Self {
-            re: T::from(n)?,
-            im: T::zero(),
-        })
+        T::from(n).map(|re| Complex { re, im: T::zero() })
     }
 }
 

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -34,7 +34,10 @@ macro_rules! impl_from_primitive {
     ($ty:ty, $from_xx:ident) => {
         #[inline]
         fn $from_xx(n: $ty) -> Option<Self> {
-            T::$from_xx(n).map(|re| Complex { re, im: T::zero() })
+            T::$from_xx(n).map(|re| Complex {
+                re: re,
+                im: T::zero(),
+            })
         }
     };
 } // impl_from_primitive
@@ -60,7 +63,10 @@ impl<T: FromPrimitive + Zero> FromPrimitive for Complex<T> {
 
 impl<T: NumCast + Num> NumCast for Complex<T> {
     fn from<U: ToPrimitive>(n: U) -> Option<Self> {
-        T::from(n).map(|re| Complex { re, im: T::zero() })
+        T::from(n).map(|re| Complex {
+            re: re,
+            im: T::zero(),
+        })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ use traits::{Inv, Num, One, Zero};
 use traits::float::Float;
 use traits::float::FloatCore;
 
+mod cast;
 #[cfg(feature = "rand")]
 mod crand;
 #[cfg(feature = "rand")]


### PR DESCRIPTION
I added a submodule `cast` which defines four traits in `num-traits::cast`:

- `ToPrimitive::to_xxx` returns `None` if `im` is non-zero
- `FromPrimitive::from_xxx(a)` returns `Complex { re: T::from_xxx(a), im: T::zero() }`
- `AsPrimitive` drops the imaginary part of complex
- `NumCast` is same as `ToPrimitive`