### PR TITLE
Fix #2: Added CommonFloat trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ features = ["std", "serde", "rand"]
 [dependencies]
 
 [dependencies.num-traits]
-version = "0.2.4"
+git = "https://github.com/YakoYakoYokuYoku/num-traits"
 default-features = false
 
 [dependencies.serde]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ use traits::{Inv, Num, One, Zero};
 #[cfg(feature = "std")]
 use traits::float::Float;
 use traits::float::FloatCore;
+use traits::float::CommonFloat;
 
 mod cast;
 #[cfg(feature = "rand")]
@@ -229,6 +230,12 @@ impl<T: Clone + Float> Complex<T> {
         // = log_y(ρ) + i θ / ln(y)
         let (r, theta) = self.to_polar();
         Complex::new(r.log(base), theta / base.ln())
+    }
+
+    /// Returns the logarithm of `self` with respect to an arbitrary base.
+    #[inline]
+    pub fn logc(&self, base: Complex<T>) -> Complex<T> {
+        self.ln() / base.ln()
     }
 
     /// Raises `self` to a complex power.
@@ -911,6 +918,108 @@ impl<T: Clone + Num> One for Complex<T> {
     #[inline]
     fn is_one(&self) -> bool {
         self.re.is_one() && self.im.is_zero()
+    }
+}
+
+impl<T: Float + FloatCore> CommonFloat for Complex<T> {
+    type Typo = T;
+
+    fn abs(self) -> T {
+        self.norm()
+    }
+    fn arg(self) -> T {
+        Complex::arg(&self)
+    }
+    fn real(self) -> T {
+        self.re
+    }
+    fn imag(self) -> T {
+        self.im
+    }
+    fn mul_add(self, a: Self, b: Self) -> Complex<T> {
+        (self * a) + b
+    }
+    fn recip(self) -> Complex<T> {
+        self.inv()
+    }
+    fn pown(self, ind: Self) -> Complex<T> {
+        self.powc(ind)
+    }
+    fn sqrt(self) -> Complex<T> {
+        Complex::sqrt(&self)
+    }
+    fn exp(self) -> Complex<T> {
+        Complex::exp(&self)
+    }
+    fn exp2(self) -> Complex<T> {
+        let lt = Complex::from(T::from(2).unwrap());
+        (self * lt).exp()
+    }
+    fn ln(self) -> Complex<T> {
+        Complex::ln(&self)
+    }
+    fn log(self, base: Self) -> Complex<T> {
+        Complex::logc(&self, base)
+    }
+    fn log2(self) -> Complex<T> {
+        let t = Complex::from(T::from(2).unwrap());
+        self.log(t)
+    }
+    fn log10(self) -> Complex<T> {
+        let s = Complex::from(T::from(10).unwrap());
+        self.log(s)
+    }
+    fn cbrt(self) -> Complex<T> {
+        let t = Complex::from(T::from(3).unwrap());
+        (self.ln() / t).exp()
+    }
+    fn sin(self) -> Complex<T> {
+        Complex::sin(&self)
+    }
+    fn cos(self) -> Complex<T> {
+        Complex::cos(&self)
+    }
+    fn tan(self) -> Complex<T> {
+        Complex::tan(&self)
+    }
+    fn asin(self) -> Complex<T> {
+        Complex::asin(&self)
+    }
+    fn acos(self) -> Complex<T> {
+        Complex::acos(&self)
+    }
+    fn atan(self) -> Complex<T> {
+        Complex::atan(&self)
+    }
+    fn sinh(self) -> Complex<T> {
+        Complex::sinh(&self)
+    }
+    fn cosh(self) -> Complex<T> {
+        Complex::cosh(&self)
+    }
+    fn tanh(self) -> Complex<T> {
+        Complex::tanh(&self)
+    }
+    fn asinh(self) -> Complex<T> {
+        Complex::asinh(&self)
+    }
+    fn acosh(self) -> Complex<T> {
+        Complex::acosh(&self)
+    }
+    fn atanh(self) -> Complex<T> {
+        Complex::atanh(&self)
+    }
+    fn is_finite(self) -> bool {
+        Complex::is_finite(self)
+    }
+    fn is_infinite(self) -> bool {
+        Complex::is_infinite(self)
+    }
+    fn is_nan(self) -> bool {
+        Complex::is_nan(self)
+    }
+    fn is_normal(self) -> bool {
+        Complex::is_normal(self)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -952,7 +952,7 @@ impl<T: Float + FloatCore> CommonFloat for Complex<T> {
         Complex::exp(&self)
     }
     fn exp2(self) -> Complex<T> {
-        let lt = Complex::from(T::from(2).unwrap());
+        let lt = Complex::from(T::from(2).unwrap().ln());
         (self * lt).exp()
     }
     fn ln(self) -> Complex<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,16 @@ impl<T: Clone + Num + Neg<Output = T>> Complex<T> {
 
 #[cfg(feature = "std")]
 impl<T: Clone + Float> Complex<T> {
+    /// Returns the real part.
+    #[inline]
+    pub fn real(&self) -> T {
+        self.re
+    }
+    /// Returns the imaginary part.
+    #[inline]
+    pub fn imag(&self) -> T {
+        self.im
+    }
     /// Calculate |self|
     #[inline]
     pub fn norm(&self) -> T {


### PR DESCRIPTION
As I was working in my [horse-shoe](https://github.com/YakoYakoYokuYoku/horse-shoe) (shameless plug) the needs for a trait that implements functions for both real and complex numbers started to rise and also to nail issue #2, that's why I am creating this PR. Now i have the means to plot real and complex numbers in Rust so we can start working in ways to implement functions for complex numbers, as for the moment I'm writing this I have a bunch of functions that works with both sets of numbuhs.

**Important:** the trait doesn't implement `PartialOrd`, we have the trait Float already.