### PR TITLE
Add l1_norm() for Signed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@ impl<T: Clone + Signed> Complex<T> {
     /// Returns the [Manhattan distance](https://en.wikipedia.org/wiki/Taxicab_geometry) `re + im`.
     #[inline]
     pub fn l1_norm(&self) -> T {
-        self.re.clone().abs() + self.im.clone().abs()
+        self.re.abs() + self.im.abs()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ use core::str::FromStr;
 #[cfg(feature = "std")]
 use std::error::Error;
 
-use traits::{Inv, Num, One, Zero, Signed};
+use traits::{Inv, Num, One, Signed, Zero};
 
 #[cfg(feature = "std")]
 use traits::float::Float;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ use core::str::FromStr;
 #[cfg(feature = "std")]
 use std::error::Error;
 
-use traits::{Inv, Num, One, Zero};
+use traits::{Inv, Num, One, Zero, Signed};
 
 #[cfg(feature = "std")]
 use traits::float::Float;
@@ -138,6 +138,14 @@ impl<T: Clone + Num + Neg<Output = T>> Complex<T> {
             self.re.clone() / norm_sqr.clone(),
             -self.im.clone() / norm_sqr,
         )
+    }
+}
+
+impl<T: Clone + Signed> Complex<T> {
+    /// Returns the [Manhattan distance](https://en.wikipedia.org/wiki/Taxicab_geometry) `re + im`.
+    #[inline]
+    pub fn l1_norm(&self) -> T {
+        self.re.clone().abs() + self.im.clone().abs()
     }
 }
 
@@ -433,12 +441,6 @@ impl<T: Clone + FloatCore> Complex<T> {
     #[inline]
     pub fn is_normal(self) -> bool {
         self.re.is_normal() && self.im.is_normal()
-    }
-
-    /// Absolute value `re + im`.
-    #[inline]
-    pub fn abs(&self) -> T {
-        self.re.clone().abs() + self.im.clone().abs()
     }
 }
 
@@ -1376,14 +1378,14 @@ mod test {
     }
 
     #[test]
-    fn test_abs() {
-        assert_eq!(_0_0i.abs(), 0.0);
-        assert_eq!(_1_0i.abs(), 1.0);
-        assert_eq!(_1_1i.abs(), 2.0);
-        assert_eq!(_0_1i.abs(), 1.0);
-        assert_eq!(_neg1_1i.abs(), 2.0);
-        assert_eq!(_05_05i.abs(), 1.0);
-        assert_eq!(_4_2i.abs(), 6.0);
+    fn test_l1_norm() {
+        assert_eq!(_0_0i.l1_norm(), 0.0);
+        assert_eq!(_1_0i.l1_norm(), 1.0);
+        assert_eq!(_1_1i.l1_norm(), 2.0);
+        assert_eq!(_0_1i.l1_norm(), 1.0);
+        assert_eq!(_neg1_1i.l1_norm(), 2.0);
+        assert_eq!(_05_05i.l1_norm(), 1.0);
+        assert_eq!(_4_2i.l1_norm(), 6.0);
     }
 
     #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -434,6 +434,12 @@ impl<T: Clone + FloatCore> Complex<T> {
     pub fn is_normal(self) -> bool {
         self.re.is_normal() && self.im.is_normal()
     }
+
+    /// Absolute value `re + im`.
+    #[inline]
+    pub fn abs(&self) -> T {
+        self.re.clone().abs() + self.im.clone().abs()
+    }
 }
 
 impl<T: Clone + Num> From<T> for Complex<T> {
@@ -1367,6 +1373,17 @@ mod test {
     fn test_inv_zero() {
         // FIXME #20: should this really fail, or just NaN?
         assert!(_0_0i.inv().is_nan());
+    }
+
+    #[test]
+    fn test_abs() {
+        assert_eq!(_0_0i.abs(), 0.0);
+        assert_eq!(_1_0i.abs(), 1.0);
+        assert_eq!(_1_1i.abs(), 2.0);
+        assert_eq!(_0_1i.abs(), 1.0);
+        assert_eq!(_neg1_1i.abs(), 2.0);
+        assert_eq!(_05_05i.abs(), 1.0);
+        assert_eq!(_4_2i.abs(), 6.0);
     }
 
     #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,9 @@ impl<T: Clone + Num + Neg<Output = T>> Complex<T> {
 }
 
 impl<T: Clone + Signed> Complex<T> {
-    /// Returns the [Manhattan distance](https://en.wikipedia.org/wiki/Taxicab_geometry) `re + im`.
+    /// Returns the L1 norm `|re| + |im|` -- the [Manhattan distance] from the origin.
+    ///
+    /// [Manhattan distance]: https://en.wikipedia.org/wiki/Taxicab_geometry
     #[inline]
     pub fn l1_norm(&self) -> T {
         self.re.abs() + self.im.abs()


### PR DESCRIPTION
Hi,
This adds the abs method for the FloatCore trait.

as far as I understand it there is no way to get the absolute value/norm of a complex number using no_std. with this method it should be possible to get absolute value with no_std.

let me know if you fine with the name abs() or want it to be norm() as pointed out in #38 

The motivation is to be able to make https://github.com/schultzer/blas-rs compile with no_std.

/edit

This is actually ["The 1-norm is simply the sum of the absolute values of the columns"](https://en.wikipedia.org/wiki/Norm_(mathematics))