### PR TITLE
Removed extern crate instruction from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,6 @@ Add this to your `Cargo.toml`:
 num-complex = "0.3"
 ```
 
-and this to your crate root:
-
-```rust
-extern crate num_complex;
-```
-
 ## Features
 
 This crate can be used without the standard library (`#![no_std]`) by disabling


### PR DESCRIPTION
As of edition 2018, downstream crates no longer have to declare `extern crate` explicitly (especially without `#[macro_use]`).