### PR TITLE
Add support for `bytemuck` traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,13 @@ exclude = ["/bors.toml", "/ci/*", "/.github/*"]
 edition = "2018"
 
 [package.metadata.docs.rs]
-features = ["std", "serde", "rand"]
+features = ["bytemuck", "std", "serde", "rand"]
 
 [dependencies]
+
+[dependencies.bytemuck]
+optional = true
+version = "1"
 
 [dependencies.num-traits]
 version = "0.2.11"

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -27,7 +27,7 @@ if ! check_version $MSRV ; then
   exit 1
 fi
 
-FEATURES=(libm serde)
+FEATURES=(libm serde bytemuck)
 check_version 1.36 && FEATURES+=(rand)
 echo "Testing supported features: ${FEATURES[*]}"
 

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -27,7 +27,8 @@ if ! check_version $MSRV ; then
   exit 1
 fi
 
-FEATURES=(libm serde bytemuck)
+FEATURES=(libm serde)
+check_version 1.34 && FEATURES+=(bytemuck)
 check_version 1.36 && FEATURES+=(rand)
 echo "Testing supported features: ${FEATURES[*]}"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -592,6 +592,18 @@ impl<T: FloatCore> Complex<T> {
     }
 }
 
+/// Saftey: `Complex<T>` is `repr(C)` and contains only instances of `T`, so we
+/// can guarantee it contains no *added* padding. Thus, if `T: Zeroable`,
+/// `Complex<T>` is also `Zeroable`
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: bytemuck::Zeroable> bytemuck::Zeroable for Complex<T> {}
+
+/// Saftey: `Complex<T>` is `repr(C)` and contains only instances of `T`, so we
+/// can guarantee it contains no *added* padding. Thus, if `T: Pod`,
+/// `Complex<T>` is also `Pod`
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: bytemuck::Pod> bytemuck::Pod for Complex<T> {}
+
 impl<T: Clone + Num> From<T> for Complex<T> {
     #[inline]
     fn from(re: T) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -592,15 +592,15 @@ impl<T: FloatCore> Complex<T> {
     }
 }
 
-/// Safety: `Complex<T>` is `repr(C)` and contains only instances of `T`, so we
-/// can guarantee it contains no *added* padding. Thus, if `T: Zeroable`,
-/// `Complex<T>` is also `Zeroable`
+// Safety: `Complex<T>` is `repr(C)` and contains only instances of `T`, so we
+// can guarantee it contains no *added* padding. Thus, if `T: Zeroable`,
+// `Complex<T>` is also `Zeroable`
 #[cfg(feature = "bytemuck")]
 unsafe impl<T: bytemuck::Zeroable> bytemuck::Zeroable for Complex<T> {}
 
-/// Safety: `Complex<T>` is `repr(C)` and contains only instances of `T`, so we
-/// can guarantee it contains no *added* padding. Thus, if `T: Pod`,
-/// `Complex<T>` is also `Pod`
+// Safety: `Complex<T>` is `repr(C)` and contains only instances of `T`, so we
+// can guarantee it contains no *added* padding. Thus, if `T: Pod`,
+// `Complex<T>` is also `Pod`
 #[cfg(feature = "bytemuck")]
 unsafe impl<T: bytemuck::Pod> bytemuck::Pod for Complex<T> {}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -592,13 +592,13 @@ impl<T: FloatCore> Complex<T> {
     }
 }
 
-/// Saftey: `Complex<T>` is `repr(C)` and contains only instances of `T`, so we
+/// Safety: `Complex<T>` is `repr(C)` and contains only instances of `T`, so we
 /// can guarantee it contains no *added* padding. Thus, if `T: Zeroable`,
 /// `Complex<T>` is also `Zeroable`
 #[cfg(feature = "bytemuck")]
 unsafe impl<T: bytemuck::Zeroable> bytemuck::Zeroable for Complex<T> {}
 
-/// Saftey: `Complex<T>` is `repr(C)` and contains only instances of `T`, so we
+/// Safety: `Complex<T>` is `repr(C)` and contains only instances of `T`, so we
 /// can guarantee it contains no *added* padding. Thus, if `T: Pod`,
 /// `Complex<T>` is also `Pod`
 #[cfg(feature = "bytemuck")]


### PR DESCRIPTION
`bytemuck` seems to be the *de facto* standard crate for safe
transmuting. Because `Complex<T>` is `repr(C)`, it would satisfy the
requirements for `Zeroable` and `Pod`, as long as `T` satisfies them as
well.

Add optional implemenations of `Zeroable` and `Pod`, gated behind the
`bytemuck` feature.

Closes #99