### PR TITLE
Add cis function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1610,11 +1610,11 @@ mod test {
 
         #[test]
         fn test_cis() {
-            assert!(close(Complex::cis(0.00 * f64::consts::TAU), _1_0i));
-            assert!(close(Complex::cis(0.25 * f64::consts::TAU), _0_1i));
-            assert!(close(Complex::cis(0.50 * f64::consts::TAU), -_1_0i));
-            assert!(close(Complex::cis(0.75 * f64::consts::TAU), -_0_1i));
-            assert!(close(Complex::cis(1.00 * f64::consts::TAU), _1_0i));
+            assert!(close(Complex::cis(0.0 * f64::consts::PI), _1_0i));
+            assert!(close(Complex::cis(0.5 * f64::consts::PI), _0_1i));
+            assert!(close(Complex::cis(1.0 * f64::consts::PI), -_1_0i));
+            assert!(close(Complex::cis(1.5 * f64::consts::PI), -_0_1i));
+            assert!(close(Complex::cis(2.0 * f64::consts::PI), _1_0i));
         }
 
         #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1611,11 +1611,11 @@ mod test {
 
         #[test]
         fn test_cis() {
-            assert!(close(Complex::cis(0.0 * f64::consts::PI), _1_0i));
-            assert!(close(Complex::cis(0.5 * f64::consts::PI), _0_1i));
-            assert!(close(Complex::cis(1.0 * f64::consts::PI), -_1_0i));
-            assert!(close(Complex::cis(1.5 * f64::consts::PI), -_0_1i));
-            assert!(close(Complex::cis(2.0 * f64::consts::PI), _1_0i));
+            assert!(close(Complex::cis(0.00 * f64::consts::TAU), _1_0i));
+            assert!(close(Complex::cis(0.25 * f64::consts::TAU), _0_1i));
+            assert!(close(Complex::cis(0.50 * f64::consts::TAU), -_1_0i));
+            assert!(close(Complex::cis(0.75 * f64::consts::TAU), -_0_1i));
+            assert!(close(Complex::cis(1.00 * f64::consts::TAU), _1_0i));
         }
 
         #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,12 +161,11 @@ impl<T: Clone + Signed> Complex<T> {
 
 #[cfg(any(feature = "std", feature = "libm"))]
 impl<T: Float> Complex<T> {
-    /// Create a new Complex with a given phase -- `exp(i * phase)`
-    ///
-    /// [cis (mathematics)]: https://en.wikipedia.org/wiki/Cis_(mathematics)
+    /// Create a new Complex with a given phase: `exp(i * phase)`.
+    /// See [cis (mathematics)](https://en.wikipedia.org/wiki/Cis_(mathematics)).
     #[inline]
     pub fn cis(phase: T) -> Self {
-        (Self::i() * phase).exp()
+        Self::new(phase.cos(), phase.sin())
     }
 
     /// Calculate |self|

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,6 +161,14 @@ impl<T: Clone + Signed> Complex<T> {
 
 #[cfg(any(feature = "std", feature = "libm"))]
 impl<T: Float> Complex<T> {
+    /// Create a new Complex with a given phase -- `exp(i * phase)`
+    ///
+    /// [cis (mathematics)]: https://en.wikipedia.org/wiki/Cis_(mathematics)
+    #[inline]
+    pub fn cis(phase: T) -> Self {
+        (Self::i() * phase).exp()
+    }
+
     /// Calculate |self|
     #[inline]
     pub fn norm(self) -> T {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1610,6 +1610,15 @@ mod test {
         use num_traits::{Float, Pow};
 
         #[test]
+        fn test_cis() {
+            assert!(close(Complex::cis(0.0 * f64::consts::PI), _1_0i));
+            assert!(close(Complex::cis(0.5 * f64::consts::PI), _0_1i));
+            assert!(close(Complex::cis(1.0 * f64::consts::PI), -_1_0i));
+            assert!(close(Complex::cis(1.5 * f64::consts::PI), -_0_1i));
+            assert!(close(Complex::cis(2.0 * f64::consts::PI), _1_0i));
+        }
+
+        #[test]
         #[cfg_attr(target_arch = "x86", ignore)]
         // FIXME #7158: (maybe?) currently failing on x86.
         #[allow(clippy::float_cmp)]


### PR DESCRIPTION
Adds a [cis function](https://en.wikipedia.org/wiki/Cis_(mathematics)) as a convenient way to construct a complex number with a specific phase/angle. Shorthand for `(Complex::i() * angle).exp()`.