### PR TITLE
Added ability to sort Complex numbers.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2890,8 +2890,19 @@ pub(crate) mod test {
             Complex64::new(8.0,43.0),
         ];
 
+        let mut expected: [Complex<f64>; 6] = [
+            Complex64::new(1.0,7.0),
+            Complex64::new(2.0,0.0),
+            Complex64::new(2.0,1.0),
+            Complex64::new(2.0,14.0),
+            Complex64::new(8.0,43.0),
+            Complex64::new(9.0,0.02),
+        ];
+
         list.sort_by(|a, b| a.partial_cmp(b).unwrap());
 
-        println!("{:?}", list);
+        for (i, el) in list.iter().enumerate() {
+            assert_eq!(el, &expected[i]);
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ pub use crate::crand::ComplexDistribution;
 ///               y: *mut Complex<f64>, incy: *const c_int);
 /// }
 /// ```
-#[derive(PartialEq, Eq, Copy, Clone, Hash, Debug, Default)]
+#[derive(PartialEq, Eq, Copy, Clone, Hash, Debug, Default, PartialOrd, Ord)]
 #[repr(C)]
 pub struct Complex<T> {
     /// Real portion of the complex number
@@ -2877,5 +2877,21 @@ pub(crate) mod test {
 
         assert_eq!(C.re, 12.3);
         assert_eq!(C.im, -4.5);
+    }
+
+    #[test]
+    fn test_sorting() {
+        let mut list: [Complex<f64>; 6] = [
+            Complex64::new(2.0,1.0),
+            Complex64::new(1.0,7.0),
+            Complex64::new(2.0,14.0),
+            Complex64::new(2.0,0.0),
+            Complex64::new(9.0,0.02),
+            Complex64::new(8.0,43.0),
+        ];
+
+        list.sort_by(|a, b| a.partial_cmp(b).unwrap());
+
+        println!("{:?}", list);
     }
 }


### PR DESCRIPTION
**Why?**

I have a lot of unit tests to write which need to check arrays of complex numbers.  

Being able to sort an array of Complex, makes it easier to write these tests (I can just sort the actual results and the expected results and compare).

