### PR TITLE
Use namespaced-features to safely bump to MSRV 1.60

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,9 +9,7 @@ jobs:
     strategy:
       matrix:
         rust: [
-          1.31.0, # 2018!
-          1.36.0, # rand
-          1.54.0, # rkyv
+          1.60.0, # MSRV
           stable,
           beta,
           nightly

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [1.31.0, stable]
+        rust: [1.60.0, stable]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [1.31.0, stable]
+        rust: [1.60.0, stable]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ version = "0.4.5"
 readme = "README.md"
 exclude = ["/ci/*", "/.github/*"]
 edition = "2018"
+rust-version = "1.60"
 
 [package.metadata.docs.rs]
 features = ["bytemuck", "std", "serde", "rkyv/size_64", "bytecheck", "rand"]
@@ -51,3 +52,8 @@ default-features = false
 default = ["std"]
 std = ["num-traits/std"]
 libm = ["num-traits/libm"]
+bytecheck = ["dep:bytecheck"]
+bytemuck = ["dep:bytemuck"]
+rand = ["dep:rand"]
+rkyv = ["dep:rkyv"]
+serde = ["dep:serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/rust-num/num-complex"
 version = "0.4.5"
 readme = "README.md"
 exclude = ["/ci/*", "/.github/*"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.60"
 
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![crate](https://img.shields.io/crates/v/num-complex.svg)](https://crates.io/crates/num-complex)
 [![documentation](https://docs.rs/num-complex/badge.svg)](https://docs.rs/num-complex)
-[![minimum rustc 1.31](https://img.shields.io/badge/rustc-1.31+-red.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
+[![minimum rustc 1.60](https://img.shields.io/badge/rustc-1.60+-red.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
 [![build status](https://github.com/rust-num/num-complex/workflows/master/badge.svg)](https://github.com/rust-num/num-complex/actions)
 
 `Complex` numbers for Rust.
@@ -37,7 +37,7 @@ Release notes are available in [RELEASES.md](RELEASES.md).
 
 ## Compatibility
 
-The `num-complex` crate is tested for rustc 1.31 and greater.
+The `num-complex` crate is tested for rustc 1.60 and greater.
 
 ## License
 

--- a/ci/rustup.sh
+++ b/ci/rustup.sh
@@ -5,6 +5,6 @@
 set -ex
 
 ci=$(dirname $0)
-for version in 1.31.0 1.36.0 1.54.0 stable beta nightly; do
+for version in 1.60.0 stable beta nightly; do
     rustup run "$version" "$ci/test_full.sh"
 done

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -3,7 +3,7 @@
 set -e
 
 CRATE=num-complex
-MSRV=1.31
+MSRV=1.60
 
 get_rust_version() {
   local array=($(rustc --version));
@@ -27,25 +27,10 @@ if ! check_version $MSRV ; then
   exit 1
 fi
 
-FEATURES=(libm serde)
-check_version 1.34 && FEATURES+=(bytemuck)
-check_version 1.36 && FEATURES+=(rand)
-check_version 1.54 && FEATURES+=(rkyv/size_64 bytecheck)
+FEATURES=(bytecheck bytemuck libm rand rkyv/size_64 serde)
 echo "Testing supported features: ${FEATURES[*]}"
 
 cargo generate-lockfile
-
-# libm 0.2.6 started using {float}::EPSILON
-check_version 1.43 || cargo update -p libm --precise 0.2.5
-
-# Some crates moved to Rust 1.56 / 2021
-check_version 1.56 || (
-  cargo update -p serde --precise 1.0.185
-  cargo update -p quote --precise 1.0.30
-  cargo update -p proc-macro2 --precise 1.0.65
-  cargo update -p rkyv --precise 0.7.40
-  cargo update -p bytecheck --precise 0.6.9
-)
 
 set -x
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,13 +213,11 @@ impl<T: Float> Complex<T> {
                 if !im.is_finite() {
                     return Self::new(T::zero(), T::zero());
                 }
-            } else {
-                if im == T::zero() || !im.is_finite() {
-                    if im.is_infinite() {
-                        im = T::nan();
-                    }
-                    return Self::new(re, im);
+            } else if im == T::zero() || !im.is_finite() {
+                if im.is_infinite() {
+                    im = T::nan();
                 }
+                return Self::new(re, im);
             }
         } else if re.is_nan() && im == T::zero() {
             return self;


### PR DESCRIPTION
Earlier versions won't see the incompatible updates at all!
