### PR TITLE
Adding SIMD Sum

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1507,21 +1507,103 @@ impl<T: Num + Clone> Num for Complex<T> {
     }
 }
 
+#[derive(Clone, Copy)]
+struct ComplexSIMD<T>([Complex<T>; 4]);
+
+impl<T: Clone + Num> ComplexSIMD<T> {
+    fn sum(&self) -> Complex<T> {
+        self.0[0].clone() + self.0[1].clone() + self.0[2].clone() + self.0[3].clone()
+    }
+}
+
+impl<T: Clone + Num> Add for ComplexSIMD<T> {
+    type Output = ComplexSIMD<T>;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self([
+            self.0[0].clone() + rhs.0[0].clone(),
+            self.0[1].clone() + rhs.0[1].clone(),
+            self.0[2].clone() + rhs.0[2].clone(),
+            self.0[3].clone() + rhs.0[3].clone(),
+        ])
+    }
+}
+
 impl<T: Num + Clone> Sum for Complex<T> {
-    fn sum<I>(iter: I) -> Self
+    fn sum<I>(mut iter: I) -> Self
     where
         I: Iterator<Item = Self>,
     {
-        iter.fold(Self::zero(), |acc, c| acc + c)
+        let mut complex_sum = ComplexSIMD::<T>([
+            Complex::zero(),
+            Complex::zero(),
+            Complex::zero(),
+            Complex::zero(),
+        ]);
+        loop {
+            if let Some(val0) = iter.next() {
+                if let Some(val1) = iter.next() {
+                    if let Some(val2) = iter.next() {
+                        if let Some(val3) = iter.next() {
+                            complex_sum = complex_sum
+                                + ComplexSIMD::<T>([
+                                    val0.clone(),
+                                    val1.clone(),
+                                    val2.clone(),
+                                    val3.clone(),
+                                ]);
+                        } else {
+                            return complex_sum.sum() + val0 + val1 + val2;
+                        }
+                    } else {
+                        return complex_sum.sum() + val0 + val1;
+                    }
+                } else {
+                    return complex_sum.sum() + val0;
+                }
+            } else {
+                return complex_sum.sum();
+            }
+        }
     }
 }
 
 impl<'a, T: 'a + Num + Clone> Sum<&'a Complex<T>> for Complex<T> {
-    fn sum<I>(iter: I) -> Self
+    fn sum<I>(mut iter: I) -> Self
     where
         I: Iterator<Item = &'a Complex<T>>,
     {
-        iter.fold(Self::zero(), |acc, c| acc + c)
+        let mut complex_sum = ComplexSIMD::<T>([
+            Complex::zero(),
+            Complex::zero(),
+            Complex::zero(),
+            Complex::zero(),
+        ]);
+        loop {
+            if let Some(val0) = iter.next() {
+                if let Some(val1) = iter.next() {
+                    if let Some(val2) = iter.next() {
+                        if let Some(val3) = iter.next() {
+                            complex_sum = complex_sum
+                                + ComplexSIMD::<T>([
+                                    val0.clone(),
+                                    val1.clone(),
+                                    val2.clone(),
+                                    val3.clone(),
+                                ]);
+                        } else {
+                            return complex_sum.sum() + val0 + val1 + val2;
+                        }
+                    } else {
+                        return complex_sum.sum() + val0 + val1;
+                    }
+                } else {
+                    return complex_sum.sum() + val0;
+                }
+            } else {
+                return complex_sum.sum();
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Right now, the sum for Complex floats do not auto-vectorize. This uses an intermediate data type during sum to vectorize the sum. There is no unsafe, and on my computer I get almost a 4x speed improvement for f32:

```
sum_simd                time:   [5.6591 µs 5.7808 µs 5.9707 µs]
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) high mild
  6 (6.00%) high severe

sum_scalar              time:   [19.787 µs 20.187 µs 20.938 µs]
Found 15 outliers among 100 measurements (15.00%)
  3 (3.00%) high mild
  12 (12.00%) high severe
```

I made a repo if you want to test the results yourself: https://github.com/michaelciraci/num-complex-simd-comparison

This however would technically be a breaking change, due to the order that the floats are summed (float1 + float2 + float3 may not equal float3 + float2 + float1).

This however might be an opportunity to have an SIMD feature for floats.

I waited to implement SIMD product to see what route you wanted to go down (if you were interested at all).