### PR TITLE
use squared_norm in finv

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -593,8 +593,8 @@ impl<T: Float> Complex<T> {
     /// ```
     #[inline]
     pub fn finv(self) -> Complex<T> {
-        let norm = self.norm();
-        self.conj() / norm / norm
+        let squared_norm = self.re.powi(2) + self.im.powi(2);
+        self.conj() / squared_norm
     }
 
     /// Returns `self/other` using floating-point operations.


### PR DESCRIPTION
minor change to finv. Instead of using the norm and dividing twice, it just directly adds the squared components and divides once.