### PR TITLE
[0.1] Disable `rustc-serialize` derives for future compilers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
 language: rust
 rust:
-  - 1.8.0
   - stable
   - beta
   - nightly
+matrix:
+  include:
+    - rust: 1.19.0
+      before_script:
+        - cargo generate-lockfile
+        - cargo update -p num-traits --precise 0.2.15
 sudo: false
 script:
   - cargo build --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,9 @@ categories = [ "algorithms", "data-structures", "science" ]
 license = "MIT/Apache-2.0"
 name = "num-complex"
 repository = "https://github.com/rust-num/num-complex"
-version = "0.1.43"
+version = "0.1.44"
 readme = "README.md"
+build = "build.rs"
 
 [dependencies]
 
@@ -29,3 +30,6 @@ version = ">= 0.7.0, < 0.9.0"
 [features]
 default = ["rustc-serialize"]
 unstable = []
+
+[build-dependencies]
+autocfg = "1.4.0"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![crate](https://img.shields.io/crates/v/num-complex.svg)](https://crates.io/crates/num-complex)
 [![documentation](https://docs.rs/num-complex/badge.svg)](https://docs.rs/num-complex)
-![minimum rustc 1.8](https://img.shields.io/badge/rustc-1.8+-red.svg)
+![minimum rustc 1.19](https://img.shields.io/badge/rustc-1.19+-red.svg)
 [![Travis status](https://travis-ci.org/rust-num/num-complex.svg?branch=master)](https://travis-ci.org/rust-num/num-complex)
 
 `Complex` numbers for Rust.
@@ -28,4 +28,4 @@ Release notes are available in [RELEASES.md](RELEASES.md).
 
 ## Compatibility
 
-The `num-complex` crate is tested for rustc 1.8 and greater.
+The `num-complex` crate is tested for rustc 1.19 and greater.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,9 @@
+# Release 0.1.44
+
+- [Disable `rustc-serialize` derives for future compilers.][137]
+
+[137]: https://github.com/rust-num/num-complex/pull/137
+
 # Release 0.1.43
 
 - [Fix a usage typo in README.md][20].

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,30 @@
+extern crate autocfg;
+
+fn main() {
+    autocfg::rerun_path("build.rs");
+    autocfg::emit_possibility(HAS_DERIVE);
+    if std::env::var_os("CARGO_FEATURE_RUSTC_SERIALIZE").is_some() {
+        let ac = autocfg::new();
+
+        // These built-in derives are being removed! (rust-lang/rust#134272)
+        //
+        // It's hard to directly probe for `derive(RustcDecodable, RustcEncodable)`, because that
+        // depends on the external `rustc-serialize` dependency. They're in `prelude::v1` where we
+        // can probe by path, but ironically only on relatively new versions, so we're also using
+        // *inaccessible* `rust_2024` as a proxy for older versions.
+        if ac.probe_raw(PRELUDE_DERIVE).is_ok() || !ac.probe_path(RUST_2024) {
+            autocfg::emit(HAS_DERIVE);
+        } else {
+            println!("cargo:warning=rustc-serialize is not supported by the current compiler");
+        }
+    }
+}
+
+const HAS_DERIVE: &str = "has_derive_rustc_serialize";
+
+const PRELUDE_DERIVE: &str = "
+#[allow(soft_unstable, deprecated)]
+pub use std::prelude::v1::{RustcDecodable, RustcEncodable};
+";
+
+const RUST_2024: &str = "std::prelude::rust_2024";

--- a/ci/rustup.sh
+++ b/ci/rustup.sh
@@ -1,12 +1,16 @@
 #!/bin/sh
 # Use rustup to locally run the same suite of tests as .travis.yml.
-# (You should first install/update 1.8.0, stable, beta, and nightly.)
+# (You should first install/update 1.19.0, stable, beta, and nightly.)
 
 set -ex
 
 export TRAVIS_RUST_VERSION
-for TRAVIS_RUST_VERSION in 1.8.0 stable beta nightly; do
+for TRAVIS_RUST_VERSION in 1.19.0 stable beta nightly; do
     run="rustup run $TRAVIS_RUST_VERSION"
+    $run cargo generate-lockfile
+    if [ "$TRAVIS_RUST_VERSION" = 1.19.0 ]; then
+      $run cargo update -p num-traits --precise 0.2.15
+    fi
     $run cargo build --verbose
     $run $PWD/ci/test_full.sh
 done

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,9 +12,10 @@
 //!
 //! ## Compatibility
 //!
-//! The `num-complex` crate is tested for rustc 1.8 and greater.
+//! The `num-complex` crate is tested for rustc 1.19 and greater.
 
 #![doc(html_root_url = "https://docs.rs/num-complex/0.1")]
+#![cfg_attr(has_derive_rustc_serialize, warn(soft_unstable))] // un-deny
 
 extern crate num_traits as traits;
 
@@ -62,7 +63,7 @@ use traits::{Zero, One, Num, Float};
 /// }
 /// ```
 #[derive(PartialEq, Eq, Copy, Clone, Hash, Debug, Default)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(has_derive_rustc_serialize, derive(RustcEncodable, RustcDecodable))]
 #[repr(C)]
 pub struct Complex<T> {
     /// Real portion of the complex number


### PR DESCRIPTION
The built-in derives are being [removed], but crater showed problems
with crates depending on `num v0.1`, where this feature is enabled by
default. With this PR, we detect the missing built-ins and disable the
derives, adding a build-script warning about it. Cargo won't show such
warnings by default from non-path dependencies, unless the build fails.

[removed]: https://github.com/rust-lang/rust/pull/134272
