### PR TITLE
Introduce `Complex::from_real()`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,14 @@ impl<T> Complex<T> {
     }
 }
 
+impl<T: Zero> Complex<T> {
+    /// Create a new `Complex` from a real number.
+    #[inline]
+    pub fn from_real(re: T) -> Self {
+        Self::new(re, T::zero())
+    }
+}
+
 impl<T: Clone + Num> Complex<T> {
     /// Returns the imaginary unit.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1681,6 +1681,25 @@ pub(crate) mod test {
     pub const _nan_nani: Complex64 = Complex::new(f64::NAN, f64::NAN);
 
     #[test]
+    fn test_from_real() {
+        for re in [
+            -3.123,
+            -1.0,
+            0.0,
+            1.0,
+            5.67,
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+        ] {
+            assert_eq!(Complex::new(re, 0.0), Complex::from_real(re));
+        }
+        {
+            let x = Complex::from_real(f64::NAN);
+            assert!(x.re.is_nan() && x.im.is_zero());
+        }
+    }
+
+    #[test]
     fn test_consts() {
         // check our constants are what Complex::new creates
         fn test(c: Complex64, r: f64, i: f64) {


### PR DESCRIPTION
Closes #140 .

This introduced the method `Complex::from_real()` as discussed in #140. Alongside a test is added.