### PR TITLE
Upgrade to `rand v0.10`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,7 @@ jobs:
       matrix:
         rust: [
           1.60.0, # MSRV
+          1.85.0, # rand
           stable,
           beta,
           nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ default-features = false
 
 [dependencies.rand]
 optional = true
-version = "0.8"
+version = "0.9"
 default-features = false
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ categories = ["algorithms", "data-structures", "science", "no-std"]
 license = "MIT OR Apache-2.0"
 name = "num-complex"
 repository = "https://github.com/rust-num/num-complex"
-version = "0.4.6"
+version = "0.5.0"
 readme = "README.md"
 exclude = ["/ci/*", "/.github/*"]
 edition = "2021"
@@ -45,7 +45,7 @@ default-features = false
 
 [dependencies.rand]
 optional = true
-version = "0.9"
+version = "0.10.0-rc.9"
 default-features = false
 
 [features]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-num-complex = "0.4"
+num-complex = "0.5"
 ```
 
 ## Features
@@ -23,7 +23,7 @@ the default `std` feature. Use this in `Cargo.toml`:
 
 ```toml
 [dependencies.num-complex]
-version = "0.4"
+version = "0.5"
 default-features = false
 ```
 

--- a/ci/rustup.sh
+++ b/ci/rustup.sh
@@ -5,6 +5,6 @@
 set -ex
 
 ci=$(dirname $0)
-for version in 1.60.0 stable beta nightly; do
+for version in 1.60.0 1.85.0 stable beta nightly; do
     rustup run "$version" "$ci/test_full.sh"
 done

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -21,17 +21,25 @@ check_version() {
   ]]
 }
 
+export CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS=fallback
+generate_lockfile() {
+  cargo generate-lockfile
+  if ! check_version 1.85 ; then
+    cargo +stable update
+  fi
+}
+
 echo "Testing $CRATE on rustc $RUST_VERSION"
 if ! check_version $MSRV ; then
   echo "The minimum for $CRATE is rustc $MSRV"
   exit 1
 fi
 
-FEATURES=(bytecheck bytemuck libm rand rkyv/size_64 serde)
+FEATURES=(bytecheck bytemuck libm rkyv/size_64 serde)
+check_version 1.85 && FEATURES+=(rand)
 echo "Testing supported features: ${FEATURES[*]}"
 
-cargo generate-lockfile
-check_version 1.63.0 || cargo update -p libm --precise 0.2.9
+generate_lockfile
 
 set -x
 

--- a/src/crand.rs
+++ b/src/crand.rs
@@ -2,13 +2,13 @@
 
 use crate::Complex;
 use num_traits::Num;
-use rand::distributions::Standard;
+use rand::distr::StandardUniform;
 use rand::prelude::*;
 
-impl<T> Distribution<Complex<T>> for Standard
+impl<T> Distribution<Complex<T>> for StandardUniform
 where
     T: Num + Clone,
-    Standard: Distribution<T>,
+    StandardUniform: Distribution<T>,
 {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Complex<T> {
         Complex::new(self.sample(rng), self.sample(rng))
@@ -68,11 +68,6 @@ fn test_rng() -> impl RngCore {
                 chunk.copy_from_slice(slice)
             }
         }
-
-        fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
-            self.fill_bytes(dest);
-            Ok(())
-        }
     }
 
     XorShiftStar {
@@ -84,7 +79,7 @@ fn test_rng() -> impl RngCore {
 fn standard_f64() {
     let mut rng = test_rng();
     for _ in 0..100 {
-        let c: Complex<f64> = rng.gen();
+        let c: Complex<f64> = rng.random();
         assert!(c.re >= 0.0 && c.re < 1.0);
         assert!(c.im >= 0.0 && c.im < 1.0);
     }
@@ -93,7 +88,7 @@ fn standard_f64() {
 #[test]
 fn generic_standard_f64() {
     let mut rng = test_rng();
-    let dist = ComplexDistribution::new(Standard, Standard);
+    let dist = ComplexDistribution::new(StandardUniform, StandardUniform);
     for _ in 0..100 {
         let c: Complex<f64> = rng.sample(dist);
         assert!(c.re >= 0.0 && c.re < 1.0);
@@ -103,11 +98,11 @@ fn generic_standard_f64() {
 
 #[test]
 fn generic_uniform_f64() {
-    use rand::distributions::Uniform;
+    use rand::distr::Uniform;
 
     let mut rng = test_rng();
-    let re = Uniform::new(-100.0, 0.0);
-    let im = Uniform::new(0.0, 100.0);
+    let re = Uniform::new(-100.0, 0.0).unwrap();
+    let im = Uniform::new(0.0, 100.0).unwrap();
     let dist = ComplexDistribution::new(re, im);
     for _ in 0..100 {
         // no type annotation required, since `Uniform` only produces one type.
@@ -119,11 +114,11 @@ fn generic_uniform_f64() {
 
 #[test]
 fn generic_mixed_f64() {
-    use rand::distributions::Uniform;
+    use rand::distr::Uniform;
 
     let mut rng = test_rng();
-    let re = Uniform::new(-100.0, 0.0);
-    let dist = ComplexDistribution::new(re, Standard);
+    let re = Uniform::new(-100.0, 0.0).unwrap();
+    let dist = ComplexDistribution::new(re, StandardUniform);
     for _ in 0..100 {
         // no type annotation required, since `Uniform` only produces one type.
         let c = rng.sample(dist);
@@ -134,11 +129,11 @@ fn generic_mixed_f64() {
 
 #[test]
 fn generic_uniform_i32() {
-    use rand::distributions::Uniform;
+    use rand::distr::Uniform;
 
     let mut rng = test_rng();
-    let re = Uniform::new(-100, 0);
-    let im = Uniform::new(0, 100);
+    let re = Uniform::new(-100, 0).unwrap();
+    let im = Uniform::new(0, 100).unwrap();
     let dist = ComplexDistribution::new(re, im);
     for _ in 0..100 {
         // no type annotation required, since `Uniform` only produces one type.

--- a/src/crand.rs
+++ b/src/crand.rs
@@ -42,31 +42,29 @@ where
 }
 
 #[cfg(test)]
-fn test_rng() -> impl RngCore {
+fn test_rng() -> impl Rng {
     /// Simple `Rng` for testing without additional dependencies
     struct XorShiftStar {
         a: u64,
     }
 
-    impl RngCore for XorShiftStar {
-        fn next_u32(&mut self) -> u32 {
-            self.next_u64() as u32
+    impl rand::TryRng for XorShiftStar {
+        type Error = core::convert::Infallible;
+
+        fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+            Ok(self.next_u64() as u32)
         }
 
-        fn next_u64(&mut self) -> u64 {
+        fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
             // https://en.wikipedia.org/wiki/Xorshift#xorshift*
             self.a ^= self.a >> 12;
             self.a ^= self.a << 25;
             self.a ^= self.a >> 27;
-            self.a.wrapping_mul(0x2545_F491_4F6C_DD1D)
+            Ok(self.a.wrapping_mul(0x2545_F491_4F6C_DD1D))
         }
 
-        fn fill_bytes(&mut self, dest: &mut [u8]) {
-            for chunk in dest.chunks_mut(8) {
-                let bytes = self.next_u64().to_le_bytes();
-                let slice = &bytes[..chunk.len()];
-                chunk.copy_from_slice(slice)
-            }
+        fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
+            rand::rand_core::utils::fill_bytes_via_next_word(dest, || self.try_next_u64())
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! The `num-complex` crate is tested for rustc 1.60 and greater.
 
-#![doc(html_root_url = "https://docs.rs/num-complex/0.4")]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![no_std]
 
 #[cfg(any(test, feature = "std"))]


### PR DESCRIPTION
This builds on @Dirreke's update to 0.9 (#144), and I apologize for never getting around to that. At this point, I think waiting for the imminent 0.10 makes more sense.